### PR TITLE
Option to let folders be deleted when they become empty

### DIFF
--- a/tasks/clean.js
+++ b/tasks/clean.js
@@ -9,11 +9,14 @@
 'use strict';
 
 module.exports = function(grunt) {
+  var fs = require('fs');
+  var path = require('path');
 
   grunt.registerMultiTask('clean', 'Clean files and folders.', function() {
     // Merge task-specific and/or target-specific options with these defaults.
     var options = this.options({
-      force: false
+      force: false,
+      deleteEmptyFolders: false
     });
 
     grunt.verbose.writeflags(options, 'Options');
@@ -25,6 +28,17 @@ module.exports = function(grunt) {
       try {
         grunt.file.delete(filepath, options);
         grunt.log.ok();
+
+        if(options.deleteEmptyFolders) {
+            var folder = path.dirname(filepath);
+            while((options.force || grunt.file.isPathInCwd(folder)) && !fs.readdirSync(folder).length) {
+                grunt.log.write('Cleaning empty folder "' + folder + '"...');
+                grunt.file.delete(folder, options);
+                grunt.log.ok();
+                folder = path.dirname(folder);
+            }
+        }
+
       } catch (e) {
         grunt.log.error();
         grunt.verbose.error(e);


### PR DESCRIPTION
I've just used that "clean" task for the first time and I found my output folder full of empty folders as deep as where the source files were located.

I thought that option would be interesting to add to grunt-contrib-clean.
