### PR TITLE
add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+docs
+test
+.jshintrc
+.travis.yml
+Gruntfile.js


### PR DESCRIPTION
During npm publish, certain files and directories can be ignored from the package.
See https://npmjs.org/doc/developers.html#Keeping-files-out-of-your-package.
This reduces the package size.
Package consumers need only the minimum files necessary to execute the package functionality.

**Keeping**
- AUTHORS
- CHANGELOG
- CONTRIBUTING.md
- LICENSE-MIT

**Ignoring**
- docs
- test
- .jshintrc
- .travis.yml
- Gruntfile.js
