### PR TITLE
use async version of rimraf

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test": "grunt test"
   },
   "dependencies": {
+    "async": "^0.9.0",
     "rimraf": "^2.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
As discussed in #66, use the async version of `rimraf` to allow retry on `EBUSY` and `ENOTEMPTY` errors on Windows.