### PR TITLE
Improved explanation of `no-write`, and added examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ This overrides this task from blocking deletion of folders outside current worki
 Type: `Boolean`  
 Default: `false`
 
-Will log messages of what would happen if the task was ran but doesn't actually delete the files.
+Will not actually delete any files or directories.
+If the task is run with the `--verbose` flag, the task will log messages of what files would have be deleted.
 
 ### Usage Examples
 
@@ -102,4 +103,4 @@ which help you deal with hidden files, process dynamic mappings and so on.
 
 Task submitted by [Tim Branyen](http://tbranyen.com/)
 
-*This file was generated on Fri Nov 13 2015 14:04:25.*
+*This file was generated on Fri Jan 22 2016 11:08:32.*

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Default: `false`
 Will not actually delete any files or directories.
 If the task is run with the `--verbose` flag, the task will log messages of what files would have be deleted.
 
+_Note: As this task property contains a hyphen, you will need to surround it with quotes._
+
 ### Usage Examples
 
 There are three formats you can use to run this task.
@@ -103,4 +105,4 @@ which help you deal with hidden files, process dynamic mappings and so on.
 
 Task submitted by [Tim Branyen](http://tbranyen.com/)
 
-*This file was generated on Fri Jan 22 2016 11:08:32.*
+*This file was generated on Fri Jan 22 2016 11:09:53.*

--- a/README.md
+++ b/README.md
@@ -75,6 +75,31 @@ clean: {
 }
 ```
 
+"Compact" and "Files Array" formats support a few [additional properties](http://gruntjs.com/configuring-tasks#files)
+which help you deal with hidden files, process dynamic mappings and so on.
+
+#### Globbing Patterns
+
+Although documented [in the Grunt Docs](http://gruntjs.com/configuring-tasks#globbing-patterns), here are some globbing pattern examples to acheive some common tasks:
+
+```js
+clean: {
+  folder: ['path/to/dir/'],
+  folder_v2: ['path/to/dir/**'],
+  contents: ['path/to/dir/*'],
+  subfolders: ['path/to/dir/*/'],
+  css: ['path/to/dir/*.css'],
+  all_css: ['path/to/dir/**/*.css']
+}
+```
+
+* __`folder`:__ Deletes the `dir/` folder
+* __`folder_v2`:__ Deletes the `dir/` folder
+* __`contents`:__ Keeps the `dir/` folder, but deletes the contents
+* __`subfolders`:__ Keeps the files inside the `dir/` folder, but deletes all subfolders
+* __`css`:__ Deletes all `*.css` files inside the `dir/` folder, excluding subfolders
+* __`all_css`:__ Deletes all `*.css` files inside the `dir/` folder and its subfolders
+
 ##### Skipping Files
 
 ```js
@@ -83,9 +108,6 @@ clean: {
   js: ["path/to/dir/*.js", "!path/to/dir/*.min.js"]
 }
 ```
-
-"Compact" and "Files Array" formats support a few [additional properties](http://gruntjs.com/configuring-tasks#files)
-which help you deal with hidden files, process dynamic mappings and so on.
 
 ###### Options
 
@@ -138,4 +160,4 @@ clean: {
 
 Task submitted by [Tim Branyen](http://tbranyen.com/)
 
-*This file was generated on Fri Jan 22 2016 11:11:40.*
+*This file was generated on Fri Jan 22 2016 12:07:21.*

--- a/README.md
+++ b/README.md
@@ -87,6 +87,39 @@ clean: {
 "Compact" and "Files Array" formats support a few [additional properties](http://gruntjs.com/configuring-tasks#files)
 which help you deal with hidden files, process dynamic mappings and so on.
 
+###### Options
+
+Options can be specified for all `clean` tasks and for each `clean:target`.
+
+####### All tasks
+
+```js
+// Prevents all targets from deleting any files
+clean: {
+  options: {
+    'no-write': true
+  },
+  build: ['dev/build'],
+  release: ['dist']
+}
+```
+
+####### Per-target
+
+```js
+// Will delete files for `build` target
+// Will NOT delete files for `release` target
+clean: {
+  build: ['dev/build'],
+  release: {
+    options: {
+      'no-write': true
+    },
+    src: ['dist']
+  }
+}
+```
+
 
 ## Release History
 
@@ -105,4 +138,4 @@ which help you deal with hidden files, process dynamic mappings and so on.
 
 Task submitted by [Tim Branyen](http://tbranyen.com/)
 
-*This file was generated on Fri Jan 22 2016 11:09:53.*
+*This file was generated on Fri Jan 22 2016 11:11:40.*

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ which help you deal with hidden files, process dynamic mappings and so on.
 
 #### Globbing Patterns
 
-Although documented [in the Grunt Docs](http://gruntjs.com/configuring-tasks#globbing-patterns), here are some globbing pattern examples to acheive some common tasks:
+Although documented [in the Grunt Docs](http://gruntjs.com/configuring-tasks#globbing-patterns), here are some globbing pattern examples to achieve some common tasks:
 
 ```js
 clean: {
@@ -160,4 +160,4 @@ clean: {
 
 Task submitted by [Tim Branyen](http://tbranyen.com/)
 
-*This file was generated on Fri Jan 22 2016 12:07:21.*
+*This file was generated on Sat Feb 13 2016 14:48:53.*

--- a/docs/clean-examples.md
+++ b/docs/clean-examples.md
@@ -32,7 +32,7 @@ which help you deal with hidden files, process dynamic mappings and so on.
 
 ## Globbing Patterns
 
-Although documented [in the Grunt Docs](http://gruntjs.com/configuring-tasks#globbing-patterns), here are some globbing pattern examples to acheive some common tasks:
+Although documented [in the Grunt Docs](http://gruntjs.com/configuring-tasks#globbing-patterns), here are some globbing pattern examples to achieve some common tasks:
 
 ```js
 clean: {

--- a/docs/clean-examples.md
+++ b/docs/clean-examples.md
@@ -27,6 +27,31 @@ clean: {
 }
 ```
 
+"Compact" and "Files Array" formats support a few [additional properties](http://gruntjs.com/configuring-tasks#files)
+which help you deal with hidden files, process dynamic mappings and so on.
+
+## Globbing Patterns
+
+Although documented [in the Grunt Docs](http://gruntjs.com/configuring-tasks#globbing-patterns), here are some globbing pattern examples to acheive some common tasks:
+
+```js
+clean: {
+  folder: ['path/to/dir/'],
+  folder_v2: ['path/to/dir/**'],
+  contents: ['path/to/dir/*'],
+  subfolders: ['path/to/dir/*/'],
+  css: ['path/to/dir/*.css'],
+  all_css: ['path/to/dir/**/*.css']
+}
+```
+
+* __`folder`:__ Deletes the `dir/` folder
+* __`folder_v2`:__ Deletes the `dir/` folder
+* __`contents`:__ Keeps the `dir/` folder, but deletes the contents
+* __`subfolders`:__ Keeps the files inside the `dir/` folder, but deletes all subfolders
+* __`css`:__ Deletes all `*.css` files inside the `dir/` folder, excluding subfolders
+* __`all_css`:__ Deletes all `*.css` files inside the `dir/` folder and its subfolders
+
 ### Skipping Files
 
 ```js
@@ -35,9 +60,6 @@ clean: {
   js: ["path/to/dir/*.js", "!path/to/dir/*.min.js"]
 }
 ```
-
-"Compact" and "Files Array" formats support a few [additional properties](http://gruntjs.com/configuring-tasks#files)
-which help you deal with hidden files, process dynamic mappings and so on.
 
 #### Options
 

--- a/docs/clean-examples.md
+++ b/docs/clean-examples.md
@@ -38,3 +38,36 @@ clean: {
 
 "Compact" and "Files Array" formats support a few [additional properties](http://gruntjs.com/configuring-tasks#files)
 which help you deal with hidden files, process dynamic mappings and so on.
+
+#### Options
+
+Options can be specified for all `clean` tasks and for each `clean:target`.
+
+##### All tasks
+
+```js
+// Prevents all targets from deleting any files
+clean: {
+  options: {
+    'no-write': true
+  },
+  build: ['dev/build'],
+  release: ['dist']
+}
+```
+
+##### Per-target
+
+```js
+// Will delete files for `build` target
+// Will NOT delete files for `release` target
+clean: {
+  build: ['dev/build'],
+  release: {
+    options: {
+      'no-write': true
+    },
+    src: ['dist']
+  }
+}
+```

--- a/docs/clean-options.md
+++ b/docs/clean-options.md
@@ -12,3 +12,5 @@ Default: `false`
 
 Will not actually delete any files or directories.
 If the task is run with the `--verbose` flag, the task will log messages of what files would have be deleted.
+
+_Note: As this task property contains a hyphen, you will need to surround it with quotes._

--- a/docs/clean-options.md
+++ b/docs/clean-options.md
@@ -10,4 +10,5 @@ This overrides this task from blocking deletion of folders outside current worki
 Type: `Boolean`  
 Default: `false`
 
-Will log messages of what would happen if the task was ran but doesn't actually delete the files.
+Will not actually delete any files or directories.
+If the task is run with the `--verbose` flag, the task will log messages of what files would have be deleted.


### PR DESCRIPTION
Made changes to documentation, attempting to make it clearer:
* Clarified that log messages only appear when flagged with "--verbose" mode
* Added important note that the `no-write` option contains a hyphen, and therefore the option needs to be surrounded in quotes in order to work (i.e. `'no-write': true`)
* Added examples for using `no-write`
* Added brief explanation of `clean` globbing pattern behaviour
  * Necessary because to the untrained eye, can lead to disastrous results!