### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ clean: {
 
 Options can be specified for all `clean` tasks and for each `clean:target`.
 
-####### All tasks
+* All tasks
 
 ```js
 // Prevents all targets from deleting any files
@@ -125,7 +125,7 @@ clean: {
 }
 ```
 
-####### Per-target
+* Per-target
 
 ```js
 // Will delete files for `build` target


### PR DESCRIPTION
7 hash symbols don't correspond to a markdown header. I've changed it to be dots.